### PR TITLE
Fixed builder method not injecting `table` in the url

### DIFF
--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -33,7 +33,7 @@ class SupabaseClient {
 
   /// Perform a table operation.
   SupabaseQueryBuilder from(String table) {
-    final url = '$restUrl/table';
+    final url = '$restUrl/$table';
     return SupabaseQueryBuilder(
       url,
       realtime,


### PR DESCRIPTION
## What kind of change does this PR introduce?

It is a bug fix.

## What is the current behavior?

Currently, when selecting the table in the builder with `.from(<table>)`, the `table` parameter won't be injected in the `url`. Instead, `"table"` will be injected as a string. This way, a table named `table` will be selected disregarding the passed parameter, usually causing an error, unless you have, indeed, a table named `table`.

## What is the new behavior?

The `table` parameter is passed correctly, fixing the aforementioned issue.