### PR TITLE
Exposed 'RealtimeSubscription'

### DIFF
--- a/lib/supabase.dart
+++ b/lib/supabase.dart
@@ -1,2 +1,5 @@
+export 'package:realtime_client/src/realtime_subscription.dart'
+    show RealtimeSubscription;
+
 export 'src/supabase.dart';
 export 'src/supabase_event_types.dart';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Exposing `RealtimeSubscription` so that you can declare variable of type `RealtimeSubscription` to later use it for unsubscribing. 

## What is the current behavior?

`RealtimeSubscription` is not exported, so cannot create variable of type `RealtimeSubscription`

## What is the new behavior?

`RealtimeSubscription` is exported, so you can create variable of type `RealtimeSubscription`

## Related issue

#4 