### PR TITLE
Exposed User

### DIFF
--- a/lib/supabase.dart
+++ b/lib/supabase.dart
@@ -1,2 +1,4 @@
+export 'package:gotrue/src/user.dart' show User;
+
 export 'src/supabase.dart';
 export 'src/supabase_event_types.dart';


### PR DESCRIPTION
## What kind of change does this PR introduce?

A new feature where the `User` class is exported. 

## What is the current behavior?

`User` class is not exported, so you cannot create variable with type `User`

## What is the new behavior?

`User` is exported

## Related PR from Supabase-js

https://github.com/supabase/supabase-js/pull/112

## Additional context

I wanted to export `User` as `AuthUser` like in the original PR from supabase-js above, but could not. If someone could help me out here  to achieve this, it would be great!
