### PR TITLE
Aligned exports with supabase-js

### DIFF
--- a/lib/src/auth_session.dart
+++ b/lib/src/auth_session.dart
@@ -1,0 +1,17 @@
+import 'package:gotrue/gotrue.dart' show Session, User;
+
+class AuthSession extends Session {
+  AuthSession(
+      {required String accessToken,
+      int? expiresIn,
+      String? refreshToken,
+      String? tokenType,
+      User? user})
+      : super(
+          accessToken: accessToken,
+          expiresIn: expiresIn,
+          refreshToken: refreshToken,
+          tokenType: tokenType,
+          user: user,
+        );
+}

--- a/lib/supabase.dart
+++ b/lib/supabase.dart
@@ -4,8 +4,9 @@
 ///
 library supabase;
 
-export 'package:realtime_client/src/realtime_subscription.dart'
-    show RealtimeSubscription;
+export 'package:realtime_client/src/realtime_subscription.dart';
+export 'package:gotrue/gotrue.dart';
+export 'src/auth_session.dart';
 export 'src/auth_user.dart';
 export 'src/supabase.dart';
 export 'src/supabase_event_types.dart';


### PR DESCRIPTION
## What kind of change does this PR introduce?

I noticed that `Provider` enum for auth was not being exported. I looked into it and decided to align the exports with [supabase-js](https://github.com/supabase/supabase-js/blob/master/src/index.ts) 

## What is the current behavior?

The exported members are not aligned with supabase-js

## What is the new behavior?

All exports should be aligned with supabase-js
