### PR TITLE
Updated and expanded README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,33 @@
 # `supabase-dart`
 
-A dart client for Supabase.
+A dart client for [Supabase](https://supabase.io/).
 
 [![pub package](https://img.shields.io/pub/v/supabase.svg)](https://pub.dev/packages/supabase)
 [![pub test](https://github.com/supabase/supabase-dart/workflows/Test/badge.svg)](https://github.com/supabase/supabase-dart/actions?query=workflow%3ATest)
 
-## Usage
+***
+
+## [What is Supabase](https://supabase.io/docs/)
+Supabase is an open source Firebase alternative. We are a service to:
+
+- listen to database changes
+- query your tables, including filtering, pagination, and deeply nested relationships (like GraphQL)
+- create, update, and delete rows
+- manage your users and their permissions
+- interact with your database using a simple UI
+
+## Usage example
+
+
+### [Database](https://supabase.io/docs/guides/database)
 
 ```dart
 import 'package:supabase/supabase.dart';
 
 main() {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
+  
+  // Select from table `countries` ordering by `name`
   final response = await client
       .from('countries')
       .select()
@@ -20,6 +36,113 @@ main() {
 }
 ```
 
+
+### [Authentication](https://supabase.io/docs/guides/auth)
+
+```dart
+import 'package:supabase/supabase.dart';
+
+main() {
+  final client = SupabaseClient('supabaseUrl', 'supabaseKey');
+
+  // Sign up user with email and password
+  final response = await client
+      .auth
+      .signUp('email', 'password');
+}
+```
+
+
+### [Storage](https://supabase.io/docs/guides/storage)
+
+```dart
+import 'package:supabase/supabase.dart';
+
+main() {
+  final client = SupabaseClient('supabaseUrl', 'supabaseKey');
+  
+  // Create file `example.txt` and upload it in `public` bucket
+  final file = File('example.txt');
+  file.writeAsStringSync('File content');
+  final storageResponse = await client
+      .storage
+      .from('public')
+      .upload('example.txt', file);
+}
+```
+
+
+## Authentication
+
+Initialize a [`SupabaseClient`](https://pub.dev/documentation/supabase/latest/supabase/SupabaseClient-class.html) by passing your **Supabase URL** and **Supabase KEY**. The keys can be found in your supabase project in `/setting/API`.
+```dart
+final client = SupabaseClient('supabaseUrl', 'supabaseKey');
+```
+The `client` has a [`auth`](https://pub.dev/documentation/supabase/latest/supabase/SupabaseClient/auth.html) attribute (of type [`GoTrueClient`](https://pub.dev/documentation/gotrue/latest/gotrue/GoTrueClient-class.html)) that you can use to authenticate your users using supabase.
+
+
+### Sign up
+
+Use the [`signUp`](https://pub.dev/documentation/gotrue/latest/gotrue/GoTrueClient/signUp.html) method, which returns a [`GotrueSessionResponse`](https://github.com/supabase/gotrue-dart/blob/7e58474b444e7d9ea303d11dd058d07f68b3d781/lib/src/gotrue_response.dart#L19).
+
+If the `error` attribute is `null`, the request was successful and the method returns `data` of type [`Session`](https://pub.dev/documentation/gotrue/latest/gotrue/Session-class.html). 
+```dart
+// Sign up user with email and password
+final response = await client.auth.signUp('email', 'password');
+
+if (response.error != null) {
+  // Error
+  print('Error: ${response.error?.message}');
+} else {
+  // Success
+  final session = response.data;
+}
+```
+
+
+### Sign in
+
+Use the [`signIn`](https://pub.dev/documentation/gotrue/latest/gotrue/GoTrueClient/signIn.html) method. It works similar to the `signUp` method.
+```dart
+// Sign in user with email and password
+final response = await client.auth.signIn(email: 'email', password: 'password');
+
+if (response.error != null) {
+  // Error
+  print('Error: ${response.error?.message}');
+} else {
+  // Success
+  final session = response.data;
+}
+```
+
+
+### Sign out
+
+Use the [`signOut`](https://pub.dev/documentation/gotrue/latest/gotrue/GoTrueClient/signOut.html) method, which returns a [`GotrueResponse`](https://github.com/supabase/gotrue-dart/blob/7e58474b444e7d9ea303d11dd058d07f68b3d781/lib/src/gotrue_response.dart#L6).
+
+Also for the sign out check that `error` is `null` to know if the request was successful.
+```dart
+// Sign out user
+final response = await client.auth.signOut();
+
+if (response.error != null) {
+  // Error
+  print('Error: ${response.error?.message}');
+} else {
+  // Success
+}
+```
+
+
+Check out the [**Official Documentation**](https://pub.dev/documentation/gotrue/latest/gotrue/gotrue-library.html) to learn all the other available methods.
+
+
+## Guides
+
+- Flutter Supabase Authentication - [Blog](https://www.sandromaglione.com/2021/04/24/flutter-supabase-authentication/)
+
+
 ## Contributing
 
 - Fork the repo on [GitHub](https://github.com/supabase/supabase-dart)
@@ -27,6 +150,7 @@ main() {
 - Commit changes to your own branch
 - Push your work back up to your fork
 - Submit a Pull request so that we can review your changes and merge
+
 
 ## License
 


### PR DESCRIPTION
This PR aims to expand the `README` file to make it easier for new developers to get started with `supabase-dart`.

The examples are designed to be easy to understand for someone who just found the package. The explanations are simple and introduce only the most important API calls. The docs then link all the necessary references to dive deeper into the API for more complex usecases.

- I added a usage example for authentication and storage.
- I added a full section on how to implement authentications. (I still did not have the chance to try database and storage, I will make another PR when I learn more about them).
- I added a _What is Supabase_ section to introduce Supabase to someone who never heard of it and just found the package on pub.dev.
- I added a _Guides_ section similar to the one that can be found on the [Supabase website](https://supabase.io/docs/guides/examples#guides).


## What kind of change does this PR introduce?
Docs update
