### PR TITLE
Enforcing 80 characters per line with Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Install dependencies
         run: pub get
 
+      - name: dartfmt
+        run: dart format lib test -l 80 --set-exit-if-changed
+
       - name: Run tests
         run: pub run test test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,5 +29,8 @@ jobs:
       - name: dartfmt
         run: dart format lib test -l 80 --set-exit-if-changed
 
+      - name: analyzer
+        run: dart analyze --fatal-warnings --fatal-infos .
+
       - name: Run tests
         run: pub run test test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:lint/analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false


### PR DESCRIPTION
This is just an idea that I thought might help the code to stay clean. Open to feedback on what everyone thinks! I can implement the same thing in all dart packages if this gets merged!

## What kind of change does this PR introduce?

Adds a new action in the Github action workflow to check if the code is 

## What is the current behavior?

Github actions will make sure the line length is set to 80 characters per line. 

## What is the new behavior?

Currently Github actions does not check if the line length is set to 80 characters per line. 

## Additional context

@phamhieu 
I was thinking of adding another action that enforces all analyzer rules to pass with something like this:
```
      - name: analyzer
        run: dart analyze --fatal-warnings --fatal-infos .

```
but all the `print` statements gets caught. What do you think about adding the above action as well as disabling `avoid_print ` in the linter? With that, we can make sure all lint rules are passing, and the print statements would not get caught. 