### PR TITLE
Export realtime_client

### DIFF
--- a/lib/supabase.dart
+++ b/lib/supabase.dart
@@ -5,7 +5,6 @@
 library supabase;
 
 export 'package:realtime_client/realtime_client.dart';
-export 'package:realtime_client/src/realtime_subscription.dart';
 export 'package:gotrue/gotrue.dart';
 export 'package:storage_client/storage_client.dart';
 export 'src/auth_session.dart';

--- a/lib/supabase.dart
+++ b/lib/supabase.dart
@@ -4,6 +4,7 @@
 ///
 library supabase;
 
+export 'package:realtime_client/realtime_client.dart';
 export 'package:realtime_client/src/realtime_subscription.dart';
 export 'package:gotrue/gotrue.dart';
 export 'package:storage_client/storage_client.dart';


### PR DESCRIPTION
Improve developer experience by not having manually import realtime_client since it's a transitive dependency

## What kind of change does this PR introduce?

Since RealtimeClient is a transitive dependency (for projects importing this package), dart doesn't automatically suggest importing from realtime_client package. So i added the one liner to supabase.dart

## What is the current behavior?

You need to manually import 'package:realtime_client/realtime_client.dart'

## What is the new behavior?
The manual import is not needed anymore.

## Additional context
-