### PR TITLE
fix: rpc params needed String as value

### DIFF
--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -47,7 +47,7 @@ class SupabaseClient {
   }
 
   /// Perform a stored procedure call.
-  PostgrestTransformBuilder rpc(String fn, {Map<String, String>? params}) {
+  PostgrestTransformBuilder rpc(String fn, {Map<String, dynamic>? params}) {
     final rest = _initPostgRESTClient();
     return rest.rpc(fn, params: params);
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes the rpc params type definition from `Map<String, String>? params` to `Map<String, dynamic>? params`

## What is the current behavior?

It's not possible to send json (Map) data to a Stored Procedure.

## What is the new behavior?
It's possible to send any kind of data. Of course, instances of classes won't work. They need a `toJson()` method.

## Additional context

The underlying `PostgrestClient.rpc` method has the following type definition: `Map? params`.
It's serialized anyway [here](https://github.com/supabase/postgrest-dart/blob/master/lib/src/postgrest_builder.dart#L72).

I tested it with a `Map` and it worked.
