### PR TITLE
fix: bug where data is added to stream after it is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ main() {
 
 ### Realtime data as `Stream`
 
+To receive relatime updates, you have to first enable Realtime on from your Supabase console. You can read more [here](https://supabase.io/docs/guides/api#managing-realtime) on how to enable it.
+
 ```dart
 import 'package:supabase/supabase.dart';
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes the bug where data is being added after StreamController has been closed. 

Related https://github.com/supabase/supabase-dart/issues/42

## What is the current behavior?

There is no check for whether StreamController is still open or not. 

## What is the new behavior?

Before adding data to StreamController, it will check if the controller is still open. 

## Additional context

I know we discussed removing `_streamController.close();`, but later noticed that removing that line might solve the bug, but that means the user is left with a streamController with no realtime update arriving as the realtime listener is removed at the same time. 