### PR TITLE
chore: added X-Client-Info header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.2.6]
+
+- chore: add `X-Client-Info` header
+- chore: update gotrue to v0.1.1
+- chore: update postgrest to v0.1.7
+- chore: update realtime_client to v0.1.11
+- chore: update storage_client to v0.0.5
+
 ## [0.2.5]
 
 - chore: update realtime_client to v0.1.10

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,0 +1,7 @@
+import 'package:supabase/src/version.dart';
+
+class Constants {
+  static const Map<String, String> defaultHeaders = {
+    'X-Client-Info': 'supabase-dart/$version',
+  };
+}

--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -17,10 +17,10 @@ class SupabaseClient {
   final String realtimeUrl;
   final String authUrl;
   final String storageUrl;
+  final Map<String, String> _headers;
 
   late final GoTrueClient auth;
   late final RealtimeClient realtime;
-  late final Map<String, String> _headers;
 
   SupabaseClient(
     this.supabaseUrl,

--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -4,6 +4,7 @@ import 'package:gotrue/gotrue.dart';
 import 'package:postgrest/postgrest.dart';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:storage_client/storage_client.dart';
+import 'package:supabase/src/constants.dart';
 import 'package:supabase/src/supabase_stream_builder.dart';
 
 import 'supabase_query_builder.dart';
@@ -19,16 +20,25 @@ class SupabaseClient {
 
   late final GoTrueClient auth;
   late final RealtimeClient realtime;
+  late final Map<String, String> _headers;
 
-  SupabaseClient(this.supabaseUrl, this.supabaseKey,
-      {String? schema, bool autoRefreshToken = true})
-      : restUrl = '$supabaseUrl/rest/v1',
+  SupabaseClient(
+    this.supabaseUrl,
+    this.supabaseKey, {
+    String? schema,
+    bool autoRefreshToken = true,
+    Map<String, String> headers = Constants.defaultHeaders,
+  })  : restUrl = '$supabaseUrl/rest/v1',
         realtimeUrl = '$supabaseUrl/realtime/v1'.replaceAll('http', 'ws'),
         authUrl = '$supabaseUrl/auth/v1',
         storageUrl = '$supabaseUrl/storage/v1',
-        schema = schema ?? 'public' {
-    auth = _initSupabaseAuthClient(autoRefreshToken: autoRefreshToken);
-    realtime = _initRealtimeClient();
+        schema = schema ?? 'public',
+        _headers = headers {
+    auth = _initSupabaseAuthClient(
+      autoRefreshToken: autoRefreshToken,
+      headers: headers,
+    );
+    realtime = _initRealtimeClient(headers: headers);
   }
 
   /// Supabase Storage allows you to manage user-generated content, such as photos or videos.
@@ -39,6 +49,8 @@ class SupabaseClient {
   SupabaseQueryBuilder from(String table) {
     late final String url;
     StreamPostgrestFilter? streamFilter;
+
+    /// Check whether there is realtime filter or not
     if (RegExp(r'^.*:.*\=eq\..*$').hasMatch(table)) {
       final tableName = table.split(':').first;
       url = '$restUrl/$tableName';
@@ -83,18 +95,29 @@ class SupabaseClient {
     return realtime.channels;
   }
 
-  GoTrueClient _initSupabaseAuthClient({bool? autoRefreshToken}) {
+  GoTrueClient _initSupabaseAuthClient({
+    bool? autoRefreshToken,
+    required Map<String, String> headers,
+  }) {
+    final authHeaders = {...headers};
+    authHeaders['apikey'] = supabaseKey;
+    authHeaders['Authorization'] = 'Bearer $supabaseKey';
+
     return GoTrueClient(
-        url: authUrl,
-        headers: {
-          'Authorization': 'Bearer $supabaseKey',
-          'apikey': supabaseKey,
-        },
-        autoRefreshToken: autoRefreshToken);
+      url: authUrl,
+      headers: authHeaders,
+      autoRefreshToken: autoRefreshToken,
+    );
   }
 
-  RealtimeClient _initRealtimeClient() {
-    return RealtimeClient(realtimeUrl, params: {'apikey': supabaseKey});
+  RealtimeClient _initRealtimeClient({
+    required Map<String, String> headers,
+  }) {
+    return RealtimeClient(
+      realtimeUrl,
+      params: {'apikey': supabaseKey},
+      headers: headers,
+    );
   }
 
   PostgrestClient _initPostgRESTClient() {
@@ -112,7 +135,7 @@ class SupabaseClient {
   }
 
   Map<String, String> _getAuthHeaders() {
-    final Map<String, String> headers = {};
+    final headers = {..._headers};
     final authBearer = auth.session()?.accessToken ?? supabaseKey;
     headers['apikey'] = supabaseKey;
     headers['Authorization'] = 'Bearer $authBearer';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.2.5';
+const version = '0.2.6';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,1 @@
+const version = '0.2.5';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  gotrue: ^0.1.0
-  postgrest: ^0.1.6
-  realtime_client: ^0.1.10
-  storage_client: ^0.0.4
+  gotrue: ^0.1.1
+  postgrest: ^0.1.7
+  realtime_client: ^0.1.11
+  storage_client: ^0.0.5
 
 dev_dependencies:
   lint: ^1.5.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 0.2.5
+version: 0.2.6
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -14,4 +14,28 @@ void main() {
     final builder = client.from('users').select();
     expect(builder.url.toString(), '/rest/v1/users?select=%2A');
   });
+
+  test('X-Client-Info header is set properly on auth', () {
+    final xClientHeaderBeforeSlash =
+        client.auth.api.headers['X-Client-Info']!.split('/').first;
+    expect(xClientHeaderBeforeSlash, 'supabase-dart');
+  });
+
+  test('X-Client-Info header is set properly on postgrest', () {
+    final xClientHeaderBeforeSlash =
+        client.from('cats').headers['X-Client-Info']!.split('/').first;
+    expect(xClientHeaderBeforeSlash, 'supabase-dart');
+  });
+
+  test('X-Client-Info header is set properly on realtime', () {
+    final xClientHeaderBeforeSlash =
+        client.realtime.headers['X-Client-Info']!.split('/').first;
+    expect(xClientHeaderBeforeSlash, 'supabase-dart');
+  });
+
+  test('X-Client-Info header is set properly on storage', () {
+    final xClientHeaderBeforeSlash =
+        client.storage.headers['X-Client-Info']!.split('/').first;
+    expect(xClientHeaderBeforeSlash, 'supabase-dart');
+  });
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -2,40 +2,78 @@ import 'package:supabase/supabase.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const supabaseUrl = '';
-  const supabaseKey = '';
-  late SupabaseClient client;
+  group('Standard Header', () {
+    const supabaseUrl = '';
+    const supabaseKey = '';
+    late SupabaseClient client;
 
-  setUp(() {
-    client = SupabaseClient(supabaseUrl, supabaseKey);
+    setUp(() {
+      client = SupabaseClient(supabaseUrl, supabaseKey);
+    });
+
+    test('postgrest builder url', () async {
+      final builder = client.from('users').select();
+      expect(builder.url.toString(), '/rest/v1/users?select=%2A');
+    });
+
+    test('X-Client-Info header is set properly on auth', () {
+      final xClientHeaderBeforeSlash =
+          client.auth.api.headers['X-Client-Info']!.split('/').first;
+      expect(xClientHeaderBeforeSlash, 'supabase-dart');
+    });
+
+    test('X-Client-Info header is set properly on postgrest', () {
+      final xClientHeaderBeforeSlash =
+          client.from('cats').headers['X-Client-Info']!.split('/').first;
+      expect(xClientHeaderBeforeSlash, 'supabase-dart');
+    });
+
+    test('X-Client-Info header is set properly on realtime', () {
+      final xClientHeaderBeforeSlash =
+          client.realtime.headers['X-Client-Info']!.split('/').first;
+      expect(xClientHeaderBeforeSlash, 'supabase-dart');
+    });
+
+    test('X-Client-Info header is set properly on storage', () {
+      final xClientHeaderBeforeSlash =
+          client.storage.headers['X-Client-Info']!.split('/').first;
+      expect(xClientHeaderBeforeSlash, 'supabase-dart');
+    });
   });
 
-  test('postgrest builder url', () async {
-    final builder = client.from('users').select();
-    expect(builder.url.toString(), '/rest/v1/users?select=%2A');
-  });
+  group('Custom Header', () {
+    const supabaseUrl = '';
+    const supabaseKey = '';
+    late SupabaseClient client;
 
-  test('X-Client-Info header is set properly on auth', () {
-    final xClientHeaderBeforeSlash =
-        client.auth.api.headers['X-Client-Info']!.split('/').first;
-    expect(xClientHeaderBeforeSlash, 'supabase-dart');
-  });
+    setUp(() {
+      client = SupabaseClient(
+        supabaseUrl,
+        supabaseKey,
+        headers: {
+          'X-Client-Info': 'supabase-flutter/0.0.0',
+        },
+      );
+    });
 
-  test('X-Client-Info header is set properly on postgrest', () {
-    final xClientHeaderBeforeSlash =
-        client.from('cats').headers['X-Client-Info']!.split('/').first;
-    expect(xClientHeaderBeforeSlash, 'supabase-dart');
-  });
+    test('X-Client-Info header is set properly on auth', () {
+      final xClientInfoHeader = client.auth.api.headers['X-Client-Info'];
+      expect(xClientInfoHeader, 'supabase-flutter/0.0.0');
+    });
 
-  test('X-Client-Info header is set properly on realtime', () {
-    final xClientHeaderBeforeSlash =
-        client.realtime.headers['X-Client-Info']!.split('/').first;
-    expect(xClientHeaderBeforeSlash, 'supabase-dart');
-  });
+    test('X-Client-Info header is set properly on postgrest', () {
+      final xClientInfoHeader = client.from('cats').headers['X-Client-Info'];
+      expect(xClientInfoHeader, 'supabase-flutter/0.0.0');
+    });
 
-  test('X-Client-Info header is set properly on storage', () {
-    final xClientHeaderBeforeSlash =
-        client.storage.headers['X-Client-Info']!.split('/').first;
-    expect(xClientHeaderBeforeSlash, 'supabase-dart');
+    test('X-Client-Info header is set properly on realtime', () {
+      final xClientInfoHeader = client.realtime.headers['X-Client-Info'];
+      expect(xClientInfoHeader, 'supabase-flutter/0.0.0');
+    });
+
+    test('X-Client-Info header is set properly on storage', () {
+      final xClientInfoHeader = client.storage.headers['X-Client-Info'];
+      expect(xClientInfoHeader, 'supabase-flutter/0.0.0');
+    });
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds `X-Client-Info` header to Supabase client. The header passed to Supabase client will override the headers of postgrest, gotrue, realtime, and storage clients. 

This PR contains:
- Code modifications to accept `headers` as a parameter of `SupabaseClient`
- Code modifications to pass the `headers` value to each client libraries
- Test code to make sure `X-Client-Info` header of each client libraries has been overridden
- Test code to make sure `X-Client-Info` header can be overridden by `supabase_flutter` library
- Bumped version to 0.2.6 so that this package can be released(by hand) once merged

Related https://github.com/supabase/supabase-dart/issues/45

## What is the current behavior?

`X-Client-Info` header cannot be set. 

## What is the new behavior?

`X-Client-Info` header will be set by default, and can be overridden by other libraries. 

## Additional context

N/A
