### PR TITLE
chore: publish version 0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.7]
+
+- chore: update postgrest to v0.1.8
+
 ## [0.2.6]
 
 - chore: add `X-Client-Info` header

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.2.6';
+const version = '0.2.7';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 0.2.6
+version: 0.2.7
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   gotrue: ^0.1.1
-  postgrest: ^0.1.7
+  postgrest: ^0.1.8
   realtime_client: ^0.1.11
   storage_client: ^0.0.5
 


### PR DESCRIPTION
Updates `postgrest` to the newest version and publish version `0.2.7` of `supabase_dart`.

