### PR TITLE
feat: add user_token when creating realtime channel subscription

### DIFF
--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -19,8 +19,12 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
     required String? table,
     required StreamPostgrestFilter? streamFilter,
   }) : super(url, headers: headers, schema: schema) {
-    _subscription =
-        SupabaseRealtimeClient(realtime, schema ?? 'public', table ?? '*');
+    _subscription = SupabaseRealtimeClient(
+      realtime,
+      headers,
+      schema ?? 'public',
+      table ?? '*',
+    );
     _realtime = realtime;
     _streamFilter = streamFilter;
   }

--- a/lib/src/supabase_realtime_client.dart
+++ b/lib/src/supabase_realtime_client.dart
@@ -10,12 +10,18 @@ class SupabaseRealtimeClient {
 
   SupabaseRealtimeClient(
     RealtimeClient socket,
+    Map<String, String> headers,
     String schema,
     String tableName,
   ) {
+    final chanParams = <String, String>{};
     final topic =
         tableName == '*' ? 'realtime:$schema' : 'realtime:$schema:$tableName';
-    subscription = socket.channel(topic);
+    final userToken = headers['Authorization']?.split(' ')[1];
+    if (userToken != null) {
+      chanParams['user_token'] = userToken;
+    }
+    subscription = socket.channel(topic, chanParams: chanParams);
   }
 
   /// The event you want to listen to.


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds `user_token` header to realtime channel subscription.

Related https://github.com/supabase/supabase-dart/issues/56
Related https://github.com/supabase/supabase-js/pull/270

## What is the current behavior?

Pass the user access token to Realtime in order to apply RLS on a per topic basis via WALRUS.

## What is the new behavior?

Not passing user_token to realtime channel subscription.
