### PR TITLE
chore: publish version 0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.10]
+
+- fix: type 'Null' is not a subtype of type 'List<dynamic>' in type cast
+
 ## [0.2.9]
 
 - feat: add user_token when creating realtime channel subscription

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.2.9';
+const version = '0.2.10';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 0.2.9
+version: 0.2.10
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Publish version 0.2.10, which includes the following changes:
- fix: type 'Null' is not a subtype of type 'List<dynamic>' in type cast
