### PR TITLE
Implement `withConverter`

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,0 +1,16 @@
+import '../supabase.dart';
+
+typedef ResponseConverter<T> = T Function(dynamic data);
+
+extension Converter on Future<PostgrestResponse> {
+  Future<T> withConverter<T>(ResponseConverter<T> converter) async {
+    final response = await this;
+    return converter(response.data);
+  }
+}
+
+extension StreamConverter on Stream<List<Map<String, dynamic>>> {
+  Stream<T> withConverter<T>(ResponseConverter<T> converter) {
+    return map<T>((data) => converter(data));
+  }
+}

--- a/lib/supabase.dart
+++ b/lib/supabase.dart
@@ -10,6 +10,7 @@ export 'package:realtime_client/realtime_client.dart';
 export 'package:storage_client/storage_client.dart';
 export 'src/auth_session.dart';
 export 'src/auth_user.dart';
+export 'src/extensions.dart';
 export 'src/supabase.dart';
 export 'src/supabase_event_types.dart';
 export 'src/supabase_query_builder.dart';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Fixes #24 

There is currently no way to map a response.

Usage:

```dart
  // query data
  final selectResponse = await client
      .from('countries')
      .select()
      .order('name', ascending: true)
      .execute(count: CountOption.exact)
      .withConverter((data) {
    return Model.fromJson(data);
  });

  // stream
  final streamSubscription = client
      .from('countries')
      .stream()
      .order('name')
      .limit(10)
      .execute()
      .withConverter((data) => Model.fromJson(data))
      .listen((snapshot) {
    print('snapshot: $snapshot');
  });
```