### PR TITLE
fix: use PostgrestFilterBuilder type for rpc

### DIFF
--- a/lib/src/supabase.dart
+++ b/lib/src/supabase.dart
@@ -71,7 +71,7 @@ class SupabaseClient {
   }
 
   /// Perform a stored procedure call.
-  PostgrestTransformBuilder rpc(String fn, {Map<String, dynamic>? params}) {
+  PostgrestFilterBuilder rpc(String fn, {Map<String, dynamic>? params}) {
     final rest = _initPostgRESTClient();
     return rest.rpc(fn, params: params);
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
You cannot call filter methods like `eq` on rpc queries.

## What is the new behavior?
Changed return type to `PostgrestFilterBuilder`. That's already the type of the underlying `rpc` method from `PostgrestClient`.
