### PR TITLE
fix: adds increment ID in channel topic inside `stream()`

### DIFF
--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -27,6 +27,9 @@ class SupabaseClient {
   String? _changedAccessToken;
   late StreamSubscription<AuthState> _authStateSubscription;
 
+  /// Increment ID of the stream to create different realtime topic for each stream
+  int _incrementId = 0;
+
   SupabaseClient(
     this.supabaseUrl,
     this.supabaseKey, {
@@ -71,6 +74,7 @@ class SupabaseClient {
   /// Perform a table operation.
   SupabaseQueryBuilder from(String table) {
     final url = '$restUrl/$table';
+    _incrementId++;
     return SupabaseQueryBuilder(
       url,
       realtime,
@@ -78,6 +82,7 @@ class SupabaseClient {
       schema: schema,
       table: table,
       httpClient: _httpClient,
+      incrementId: _incrementId,
     );
   }
 

--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -6,6 +6,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   final RealtimeClient _realtime;
   final String _schema;
   final String _table;
+  final int _incrementId;
 
   SupabaseQueryBuilder(
     String url,
@@ -14,9 +15,11 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
     required String schema,
     required String table,
     Client? httpClient,
+    required int incrementId,
   })  : _realtime = realtime,
         _schema = schema,
         _table = table,
+        _incrementId = incrementId,
         super(
           url,
           headers: headers,
@@ -46,6 +49,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
       schema: _schema,
       table: _table,
       primaryKey: primaryKey,
+      incrementId: _incrementId,
     );
   }
 }

--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -45,11 +45,10 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
     return SupabaseStreamBuilder(
       queryBuilder: this,
       realtimeClient: _realtime,
-      realtimeTopic: '$_schema:$_table',
+      realtimeTopic: '$_schema:$_table:$_incrementId',
       schema: _schema,
       table: _table,
       primaryKey: primaryKey,
-      incrementId: _incrementId,
     );
   }
 }

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -49,9 +49,6 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Used to identify which row has changed
   final List<String> _uniqueColumns;
 
-  /// Increment ID of the stream to create different realtime topic for each stream
-  final int _incrementId;
-
   /// StreamController for `stream()` method.
   BehaviorSubject<SupabaseStreamEvent>? _streamController;
 
@@ -74,14 +71,12 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     required String schema,
     required String table,
     required List<String> primaryKey,
-    required int incrementId,
   })  : _queryBuilder = queryBuilder,
         _realtimeTopic = realtimeTopic,
         _realtimeClient = realtimeClient,
         _schema = schema,
         _table = table,
-        _uniqueColumns = primaryKey,
-        _incrementId = incrementId;
+        _uniqueColumns = primaryKey;
 
   /// Filters the results where [column] equals [value].
   ///
@@ -270,7 +265,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           '${currentStreamFilter.column}=${currentStreamFilter.type.name}.${currentStreamFilter.value}';
     }
 
-    _channel = _realtimeClient.channel('$_realtimeTopic:$_incrementId');
+    _channel = _realtimeClient.channel(_realtimeTopic);
     _channel!.on(
         RealtimeListenTypes.postgresChanges,
         ChannelFilter(

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -18,7 +18,7 @@ class _StreamPostgrestFilter {
   /// Value of the eq filter
   final dynamic value;
 
-  // Type of the filer being applied
+  /// Type of the filer being applied
   final _FilterType type;
 }
 
@@ -49,6 +49,9 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   /// Used to identify which row has changed
   final List<String> _uniqueColumns;
 
+  /// Increment ID of the stream to create different realtime topic for each stream
+  final int _incrementId;
+
   /// StreamController for `stream()` method.
   BehaviorSubject<SupabaseStreamEvent>? _streamController;
 
@@ -71,12 +74,14 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     required String schema,
     required String table,
     required List<String> primaryKey,
+    required int incrementId,
   })  : _queryBuilder = queryBuilder,
         _realtimeTopic = realtimeTopic,
         _realtimeClient = realtimeClient,
         _schema = schema,
         _table = table,
-        _uniqueColumns = primaryKey;
+        _uniqueColumns = primaryKey,
+        _incrementId = incrementId;
 
   /// Filters the results where [column] equals [value].
   ///
@@ -265,8 +270,7 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           '${currentStreamFilter.column}=${currentStreamFilter.type.name}.${currentStreamFilter.value}';
     }
 
-    _channel =
-        _realtimeClient.channel('$_realtimeTopic${realtimeFilter ?? ''}');
+    _channel = _realtimeClient.channel('$_realtimeTopic:$_incrementId');
     _channel!.on(
         RealtimeListenTypes.postgresChanges,
         ChannelFilter(

--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -265,7 +265,8 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
           '${currentStreamFilter.column}=${currentStreamFilter.type.name}.${currentStreamFilter.value}';
     }
 
-    _channel = _realtimeClient.channel(_realtimeTopic);
+    _channel =
+        _realtimeClient.channel('$_realtimeTopic${realtimeFilter ?? ''}');
     _channel!.on(
         RealtimeListenTypes.postgresChanges,
         ChannelFilter(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, when users listen to the same table multiple times, it creates the same realtime channel topic under the hood, which causes the stream to not return realtime data. This PR changes the topic to be the following format to make sure every stream creates a unique topic.

schema:table:incrementing_id

Related https://github.com/supabase/supabase-flutter/issues/231