### PR TITLE
add YAJsonIsolate instance to super constructor

### DIFF
--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart';
 import 'package:supabase/src/supabase_stream_builder.dart';
 import 'package:supabase/supabase.dart';
+import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   final RealtimeClient _realtime;
@@ -20,12 +21,11 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
         _schema = schema,
         _table = table,
         _incrementId = incrementId,
-        super(
-          url,
-          headers: headers,
-          schema: schema,
-          httpClient: httpClient,
-        );
+        super(url,
+            headers: headers,
+            schema: schema,
+            httpClient: httpClient,
+            isolate: YAJsonIsolate()..initialize());
 
   /// Notifies of data at the queried table
   ///


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

No Issue about this.

## What is the new behavior?

As in pub.dev it's descibed, the package didn't pass the static analysis and in actual development, I couldn't build for ios. I just added required params like following. I don't know if it's right way to use YAJsonIsolate but it works anyway.

## Additional context

None