### PR TITLE
Update supabase_query_builder.dart

### DIFF
--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -32,13 +32,13 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   /// [primaryKey] list of name of primary key column(s).
   ///
   /// ```dart
-  /// supabase.from('chats').stream(primaryKey: ['my_primary_key']).execute().listen(_onChatsReceived);
+  /// supabase.from('chats').stream(primaryKey: ['my_primary_key']).listen(_onChatsReceived);
   /// ```
   ///
   /// `eq`, `order`, `limit` filter are available to limit the data being queried.
   ///
   /// ```dart
-  /// supabase.from('chats:room_id=eq.123').stream(primaryKey: ['my_primary_key']).order('created_at').limit(20).execute().listen(_onChatsReceived);
+  /// supabase.from('chats:room_id=eq.123').stream(primaryKey: ['my_primary_key']).order('created_at').limit(20).listen(_onChatsReceived);
   /// ```
   SupabaseStreamBuilder stream({required List<String> primaryKey}) {
     assert(primaryKey.isNotEmpty, 'Please specify primary key column(s).');


### PR DESCRIPTION
Remove deprecated `execute()` from the docs on Streambuilder.

## What kind of change does this PR introduce?

docs update, ...

## What is the current behavior?

Nothing to link to, but as a new supabase user, I was copy/pasting from the docs, and found this `execute()` call that showed as deprecated

## What is the new behavior?

no deprecated code in this line of the docs

