### PR TITLE
fix: handle update and delete on record that wasn't found properly

### DIFF
--- a/lib/src/supabase_stream_builder.dart
+++ b/lib/src/supabase_stream_builder.dart
@@ -289,10 +289,11 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         (element) => _isTargetRecord(record: element, payload: payload),
       );
 
+      final updatedRecord = Map<String, dynamic>.from(payload['new']!);
       if (updatedIndex >= 0) {
-        _streamData[updatedIndex] = payload['new']!;
+        _streamData[updatedIndex] = updatedRecord;
       } else {
-        _addException(Exception('Could not find the updated record.'));
+        _streamData.add(updatedRecord);
       }
       _addStream();
     }).on(
@@ -307,11 +308,10 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
         (element) => _isTargetRecord(record: element, payload: payload),
       );
       if (deletedIndex >= 0) {
+        /// Delete the data from in memory cache if it was found
         _streamData.removeAt(deletedIndex);
-      } else {
-        _addException(Exception('Could not find the deleted record.'));
+        _addStream();
       }
-      _addStream();
     }).subscribe();
 
     PostgrestFilterBuilder query = _queryBuilder.select();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Related https://github.com/supabase/supabase-flutter/issues/319

## What is the current behavior?

Currently when using `.stream()`, the SDK throws if it receives an update or delete event for a record not in the in memory cache. However, situation like this could happen in a situation described in this issue https://github.com/supabase/supabase-flutter/issues/319
, or simply because the device was temporary offline, losing some events, and coming back online and receiving the delete or update events for the record that was missed, so throwing an error probably is not the ideal behavior. 

## What is the new behavior?

If an update event was received for record that does not exist in the cache, it will simply add the record and treat it like an insert. If an delete event of an record that does not exist was received, the SDK will just ignore it.