### PR TITLE
feat: use single isolate for functions and postgrest

### DIFF
--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -8,6 +8,7 @@ import 'package:realtime_client/realtime_client.dart';
 import 'package:storage_client/storage_client.dart';
 import 'package:supabase/src/constants.dart';
 import 'package:supabase/src/supabase_query_builder.dart';
+import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 class SupabaseClient {
   final String supabaseUrl;
@@ -26,6 +27,7 @@ class SupabaseClient {
   late final PostgrestClient rest;
   String? _changedAccessToken;
   late StreamSubscription<AuthState> _authStateSubscription;
+  late final YAJsonIsolate _isolate;
 
   /// Increment ID of the stream to create different realtime topic for each stream
   int _incrementId = 0;
@@ -64,7 +66,8 @@ class SupabaseClient {
         schema = schema ?? 'public',
         _headers = headers,
         _httpClient = httpClient,
-        _storageRetryAttempts = storageRetryAttempts {
+        _storageRetryAttempts = storageRetryAttempts,
+        _isolate = YAJsonIsolate() {
     auth = _initSupabaseAuthClient(
       autoRefreshToken: autoRefreshToken,
       headers: headers,
@@ -79,6 +82,7 @@ class SupabaseClient {
         functionsUrl,
         _getAuthHeaders(),
         httpClient: _httpClient,
+        isolate: _isolate,
       );
 
   /// Supabase Storage allows you to manage user-generated content, such as photos or videos.
@@ -101,6 +105,7 @@ class SupabaseClient {
       table: table,
       httpClient: _httpClient,
       incrementId: _incrementId,
+      isolate: _isolate,
     );
   }
 

--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart';
 import 'package:supabase/src/supabase_stream_builder.dart';
 import 'package:supabase/supabase.dart';
+import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
 class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   final RealtimeClient _realtime;
@@ -16,6 +17,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
     required String table,
     Client? httpClient,
     required int incrementId,
+    required YAJsonIsolate isolate,
   })  : _realtime = realtime,
         _schema = schema,
         _table = table,
@@ -25,6 +27,7 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
           headers: headers,
           schema: schema,
           httpClient: httpClient,
+          isolate: isolate,
         );
 
   /// Notifies of data at the queried table

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,14 @@ environment:
   sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
-  functions_client: ^1.0.0
+  functions_client: ^1.0.1
   gotrue: ^1.4.0
   http: ^0.13.4
   postgrest: ^1.2.1
   realtime_client: ^1.0.2
   storage_client: ^1.2.0
   rxdart: ^0.27.5
+  yet_another_json_isolate: ^1.0.1
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
## What kind of change does this PR introduce?

Instantiates a single instance of `YAJsonIsolate` and reuses it for Postgrest and functions-dart.