### PR TITLE
feat: realtimeClientOptions to SupabaseClient

### DIFF
--- a/lib/src/realtime_client_options.dart
+++ b/lib/src/realtime_client_options.dart
@@ -1,0 +1,10 @@
+/// {@template realtime_client_options}
+/// Options to pass to the RealtimeClient
+/// {@endtemplate}
+class RealtimeClientOptions {
+  /// How many events the RealtimeClient can push in a second
+  final int? eventsPerSecond;
+
+  /// {@macro realtime_client_options}
+  const RealtimeClientOptions({this.eventsPerSecond});
+}

--- a/lib/src/realtime_params.dart
+++ b/lib/src/realtime_params.dart
@@ -1,5 +1,0 @@
-class RealtimeClientOptions {
-  final int? eventsPerSecond;
-
-  const RealtimeClientOptions({this.eventsPerSecond});
-}

--- a/lib/src/realtime_params.dart
+++ b/lib/src/realtime_params.dart
@@ -1,0 +1,5 @@
+class RealtimeClientOptions {
+  final int? eventsPerSecond;
+
+  const RealtimeClientOptions({this.eventsPerSecond});
+}

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -7,6 +7,7 @@ import 'package:postgrest/postgrest.dart';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:storage_client/storage_client.dart';
 import 'package:supabase/src/constants.dart';
+import 'package:supabase/src/realtime_params.dart';
 import 'package:supabase/src/supabase_query_builder.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
@@ -60,7 +61,7 @@ class SupabaseClient {
     Map<String, String> headers = Constants.defaultHeaders,
     Client? httpClient,
     int storageRetryAttempts = 0,
-    Map<String, dynamic> realtimeParams = const {},
+    RealtimeClientOptions realtimeClientOptions = const RealtimeClientOptions(),
     YAJsonIsolate? isolate,
   })  : restUrl = '$supabaseUrl/rest/v1',
         realtimeUrl = '$supabaseUrl/realtime/v1'.replaceAll('http', 'ws'),
@@ -81,7 +82,7 @@ class SupabaseClient {
     );
     realtime = _initRealtimeClient(
       headers: headers,
-      params: realtimeParams,
+      options: realtimeClientOptions,
     );
 
     _listenForAuthEvents();
@@ -175,11 +176,15 @@ class SupabaseClient {
 
   RealtimeClient _initRealtimeClient({
     required Map<String, String> headers,
-    required Map<String, dynamic> params,
+    required RealtimeClientOptions options,
   }) {
+    final eventsPerSecond = options.eventsPerSecond;
     return RealtimeClient(
       realtimeUrl,
-      params: {'apikey': supabaseKey, ...params},
+      params: {
+        'apikey': supabaseKey,
+        if (eventsPerSecond != null) 'eventsPerSecond': eventsPerSecond
+      },
       headers: headers,
     );
   }

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -183,7 +183,7 @@ class SupabaseClient {
       realtimeUrl,
       params: {
         'apikey': supabaseKey,
-        if (eventsPerSecond != null) 'eventsPerSecond': eventsPerSecond
+        if (eventsPerSecond != null) 'eventsPerSecond': '$eventsPerSecond'
       },
       headers: headers,
     );

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -7,7 +7,7 @@ import 'package:postgrest/postgrest.dart';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:storage_client/storage_client.dart';
 import 'package:supabase/src/constants.dart';
-import 'package:supabase/src/realtime_params.dart';
+import 'package:supabase/src/realtime_client_options.dart';
 import 'package:supabase/src/supabase_query_builder.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
@@ -49,7 +49,7 @@ class SupabaseClient {
   /// [storageRetryAttempts] specifies how many retry attempts there should be to
   ///  upload a file to Supabase storage when failed due to network interruption.
   ///
-  /// [realtimeParams] sets the parameters on realtime client.
+  /// [realtimeClientOptions] specifies different options you can pass to `RealtimeClient`.
   ///
   /// Pass an instance of `YAJsonIsolate` to [isolate] to use your own persisted
   /// isolate instance. A new instance will be created if [isolate] is omitted.

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -48,6 +48,8 @@ class SupabaseClient {
   /// [storageRetryAttempts] specifies how many retry attempts there should be to
   ///  upload a file to Supabase storage when failed due to network interruption.
   ///
+  /// [realtimeParams] sets the parameters on realtime client.
+  ///
   /// Pass an instance of `YAJsonIsolate` to [isolate] to use your own persisted
   /// isolate instance. A new instance will be created if [isolate] is omitted.
   SupabaseClient(
@@ -58,6 +60,7 @@ class SupabaseClient {
     Map<String, String> headers = Constants.defaultHeaders,
     Client? httpClient,
     int storageRetryAttempts = 0,
+    Map<String, dynamic> realtimeParams = const {},
     YAJsonIsolate? isolate,
   })  : restUrl = '$supabaseUrl/rest/v1',
         realtimeUrl = '$supabaseUrl/realtime/v1'.replaceAll('http', 'ws'),
@@ -76,7 +79,10 @@ class SupabaseClient {
       autoRefreshToken: autoRefreshToken,
       headers: headers,
     );
-    realtime = _initRealtimeClient(headers: headers);
+    realtime = _initRealtimeClient(
+      headers: headers,
+      params: realtimeParams,
+    );
 
     _listenForAuthEvents();
   }
@@ -169,10 +175,11 @@ class SupabaseClient {
 
   RealtimeClient _initRealtimeClient({
     required Map<String, String> headers,
+    required Map<String, dynamic> params,
   }) {
     return RealtimeClient(
       realtimeUrl,
-      params: {'apikey': supabaseKey},
+      params: {'apikey': supabaseKey, ...params},
       headers: headers,
     );
   }

--- a/lib/supabase.dart
+++ b/lib/supabase.dart
@@ -11,6 +11,7 @@ export 'package:realtime_client/realtime_client.dart';
 export 'package:storage_client/storage_client.dart';
 
 export 'src/auth_user.dart';
+export 'src/realtime_client_options.dart';
 export 'src/remove_subscription_result.dart';
 export 'src/supabase_client.dart';
 export 'src/supabase_event_types.dart';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Realtime client has a [eventsPerSecond](https://github.com/supabase/realtime-dart/blob/main/lib/src/realtime_client.dart#L81) parameter, that can be overridden by passing it to the `params` parameter on the constructore of `RealtimeClient`. 

This PR adds a new `realtimeClientOptions` parameter of type `RealtimeClientOptions` to the `SupabaseClient` constructor and adds `eventsPerSecond` parameter.

## Other context

I'm working on a realtime gaming app using Supabase and Flame, and with because of not being able to override `eventsPerSecond`, I can only send broadcast events 10 times a second, which makes the game feel not so smooth. Adding this option and bringing the eventsPerSecond up to 30 made it look very smoooth.