### PR TITLE
fix: reuse isolate for `.rpc()` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.1]
+
+- fix: reuse isolate for `.rpc()` call [#177](https://github.com/supabase/supabase-dart/pull/177)
+
 ## [1.5.0]
 
 - feat: add `realtimeClientOptions` to SupabaseClient [#173](https://github.com/supabase/supabase-dart/pull/173)

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -131,6 +131,7 @@ class SupabaseClient {
       headers: _getAuthHeaders(),
       schema: schema,
       httpClient: _httpClient,
+      isolate: _isolate,
     ).rpc(fn, params: params, options: options);
   }
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.5.0';
+const version = '1.5.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 1.5.0
+version: 1.5.1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reuses isolate for `rpc` call.

Fixes https://github.com/supabase/supabase-flutter/issues/353