### PR TITLE
chore: make it impossible to chain filters on `.stream()`

### DIFF
--- a/lib/src/stream/supabase_stream_builder.dart
+++ b/lib/src/stream/supabase_stream_builder.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:rxdart/rxdart.dart';
 import 'package:supabase/supabase.dart';

--- a/lib/src/stream/supabase_stream_builder.dart
+++ b/lib/src/stream/supabase_stream_builder.dart
@@ -7,10 +7,10 @@ part 'supabase_stream_filter_builder.dart';
 part 'supabase_stream_limit_builder.dart';
 part 'supabase_stream_order_builder.dart';
 
-enum StreamFilterType { eq, neq, lt, lte, gt, gte }
+enum _StreamFilterType { eq, neq, lt, lte, gt, gte }
 
-class StreamFilter {
-  StreamFilter({
+class _StreamFilter {
+  _StreamFilter({
     required this.column,
     required this.value,
     required this.type,
@@ -23,11 +23,11 @@ class StreamFilter {
   final dynamic value;
 
   /// Type of the filer being applied
-  final StreamFilterType type;
+  final _StreamFilterType type;
 }
 
-class StreamOrder {
-  StreamOrder({
+class _StreamOrder {
+  _StreamOrder({
     required this.column,
     required this.ascending,
   });
@@ -60,10 +60,10 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
   SupabaseStreamEvent _streamData = [];
 
   /// `eq` filter used for both postgrest and realtime
-  final StreamFilter? _filter;
+  final _StreamFilter? _filter;
 
   /// Which column to order by and whether it's ascending
-  final StreamOrder? _order;
+  final _StreamOrder? _order;
 
   /// Count of record to be returned
   final int? _limit;
@@ -75,8 +75,8 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     required String schema,
     required String table,
     required List<String> primaryKey,
-    required StreamFilter? filter,
-    required StreamOrder? order,
+    required _StreamFilter? filter,
+    required _StreamOrder? order,
     required int? limit,
   })  : _queryBuilder = queryBuilder,
         _realtimeTopic = realtimeTopic,
@@ -185,22 +185,22 @@ class SupabaseStreamBuilder extends Stream<SupabaseStreamEvent> {
     PostgrestFilterBuilder query = _queryBuilder.select();
     if (_filter != null) {
       switch (_filter!.type) {
-        case StreamFilterType.eq:
+        case _StreamFilterType.eq:
           query = query.eq(_filter!.column, _filter!.value);
           break;
-        case StreamFilterType.neq:
+        case _StreamFilterType.neq:
           query = query.neq(_filter!.column, _filter!.value);
           break;
-        case StreamFilterType.lt:
+        case _StreamFilterType.lt:
           query = query.lt(_filter!.column, _filter!.value);
           break;
-        case StreamFilterType.lte:
+        case _StreamFilterType.lte:
           query = query.lte(_filter!.column, _filter!.value);
           break;
-        case StreamFilterType.gt:
+        case _StreamFilterType.gt:
           query = query.gt(_filter!.column, _filter!.value);
           break;
-        case StreamFilterType.gte:
+        case _StreamFilterType.gte:
           query = query.gte(_filter!.column, _filter!.value);
           break;
       }

--- a/lib/src/stream/supabase_stream_filter_builder.dart
+++ b/lib/src/stream/supabase_stream_filter_builder.dart
@@ -1,0 +1,159 @@
+part of 'supabase_stream_builder.dart';
+
+class SupabaseStreamFilterBuilder extends SupabaseStreamOrderBuilder {
+  SupabaseStreamFilterBuilder({
+    required PostgrestQueryBuilder queryBuilder,
+    required String realtimeTopic,
+    required RealtimeClient realtimeClient,
+    required String schema,
+    required String table,
+    required List<String> primaryKey,
+  }) : super(
+          queryBuilder: queryBuilder,
+          realtimeTopic: realtimeTopic,
+          realtimeClient: realtimeClient,
+          schema: schema,
+          table: table,
+          primaryKey: primaryKey,
+          filter: null,
+        );
+
+  /// Filters the results where [column] equals [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).eq('name', 'Supabase');
+  /// ```
+  SupabaseStreamOrderBuilder eq(String column, dynamic value) {
+    return SupabaseStreamOrderBuilder(
+      queryBuilder: _queryBuilder,
+      realtimeTopic: _realtimeTopic,
+      realtimeClient: _realtimeClient,
+      schema: _schema,
+      table: _table,
+      primaryKey: _uniqueColumns,
+      filter: StreamFilter(
+        type: StreamFilterType.eq,
+        column: column,
+        value: value,
+      ),
+    );
+  }
+
+  /// Filters the results where [column] does not equal [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).neq('name', 'Supabase');
+  /// ```
+  @override
+  SupabaseStreamOrderBuilder neq(String column, dynamic value) {
+    return SupabaseStreamOrderBuilder(
+      queryBuilder: _queryBuilder,
+      realtimeTopic: _realtimeTopic,
+      realtimeClient: _realtimeClient,
+      schema: _schema,
+      table: _table,
+      primaryKey: _uniqueColumns,
+      filter: StreamFilter(
+        type: StreamFilterType.neq,
+        column: column,
+        value: value,
+      ),
+    );
+  }
+
+  /// Filters the results where [column] is less than [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).lt('likes', 100);
+  /// ```
+  SupabaseStreamOrderBuilder lt(String column, dynamic value) {
+    return SupabaseStreamOrderBuilder(
+      queryBuilder: _queryBuilder,
+      realtimeTopic: _realtimeTopic,
+      realtimeClient: _realtimeClient,
+      schema: _schema,
+      table: _table,
+      primaryKey: _uniqueColumns,
+      filter: StreamFilter(
+        type: StreamFilterType.lt,
+        column: column,
+        value: value,
+      ),
+    );
+  }
+
+  /// Filters the results where [column] is less than or equal to [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).lte('likes', 100);
+  /// ```
+  SupabaseStreamOrderBuilder lte(String column, dynamic value) {
+    return SupabaseStreamOrderBuilder(
+      queryBuilder: _queryBuilder,
+      realtimeTopic: _realtimeTopic,
+      realtimeClient: _realtimeClient,
+      schema: _schema,
+      table: _table,
+      primaryKey: _uniqueColumns,
+      filter: StreamFilter(
+        type: StreamFilterType.lte,
+        column: column,
+        value: value,
+      ),
+    );
+  }
+
+  /// Filters the results where [column] is greater than [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).gt('likes', '100');
+  /// ```
+  SupabaseStreamOrderBuilder gt(String column, dynamic value) {
+    return SupabaseStreamOrderBuilder(
+      queryBuilder: _queryBuilder,
+      realtimeTopic: _realtimeTopic,
+      realtimeClient: _realtimeClient,
+      schema: _schema,
+      table: _table,
+      primaryKey: _uniqueColumns,
+      filter: StreamFilter(
+        type: StreamFilterType.gt,
+        column: column,
+        value: value,
+      ),
+    );
+  }
+
+  /// Filters the results where [column] is greater than or equal to [value].
+  ///
+  /// Only one filter can be applied to `.stream()`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).gte('likes', 100);
+  /// ```
+  SupabaseStreamOrderBuilder gte(String column, dynamic value) {
+    return SupabaseStreamOrderBuilder(
+      queryBuilder: _queryBuilder,
+      realtimeTopic: _realtimeTopic,
+      realtimeClient: _realtimeClient,
+      schema: _schema,
+      table: _table,
+      primaryKey: _uniqueColumns,
+      filter: StreamFilter(
+        type: StreamFilterType.gte,
+        column: column,
+        value: value,
+      ),
+    );
+  }
+}

--- a/lib/src/stream/supabase_stream_filter_builder.dart
+++ b/lib/src/stream/supabase_stream_filter_builder.dart
@@ -48,7 +48,6 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamOrderBuilder {
   /// ```dart
   /// supabase.from('users').stream(primaryKey: ['id']).neq('name', 'Supabase');
   /// ```
-  @override
   SupabaseStreamOrderBuilder neq(String column, dynamic value) {
     return SupabaseStreamOrderBuilder(
       queryBuilder: _queryBuilder,

--- a/lib/src/stream/supabase_stream_filter_builder.dart
+++ b/lib/src/stream/supabase_stream_filter_builder.dart
@@ -33,8 +33,8 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamOrderBuilder {
       schema: _schema,
       table: _table,
       primaryKey: _uniqueColumns,
-      filter: StreamFilter(
-        type: StreamFilterType.eq,
+      filter: _StreamFilter(
+        type: _StreamFilterType.eq,
         column: column,
         value: value,
       ),
@@ -56,8 +56,8 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamOrderBuilder {
       schema: _schema,
       table: _table,
       primaryKey: _uniqueColumns,
-      filter: StreamFilter(
-        type: StreamFilterType.neq,
+      filter: _StreamFilter(
+        type: _StreamFilterType.neq,
         column: column,
         value: value,
       ),
@@ -79,8 +79,8 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamOrderBuilder {
       schema: _schema,
       table: _table,
       primaryKey: _uniqueColumns,
-      filter: StreamFilter(
-        type: StreamFilterType.lt,
+      filter: _StreamFilter(
+        type: _StreamFilterType.lt,
         column: column,
         value: value,
       ),
@@ -102,8 +102,8 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamOrderBuilder {
       schema: _schema,
       table: _table,
       primaryKey: _uniqueColumns,
-      filter: StreamFilter(
-        type: StreamFilterType.lte,
+      filter: _StreamFilter(
+        type: _StreamFilterType.lte,
         column: column,
         value: value,
       ),
@@ -125,8 +125,8 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamOrderBuilder {
       schema: _schema,
       table: _table,
       primaryKey: _uniqueColumns,
-      filter: StreamFilter(
-        type: StreamFilterType.gt,
+      filter: _StreamFilter(
+        type: _StreamFilterType.gt,
         column: column,
         value: value,
       ),
@@ -148,8 +148,8 @@ class SupabaseStreamFilterBuilder extends SupabaseStreamOrderBuilder {
       schema: _schema,
       table: _table,
       primaryKey: _uniqueColumns,
-      filter: StreamFilter(
-        type: StreamFilterType.gte,
+      filter: _StreamFilter(
+        type: _StreamFilterType.gte,
         column: column,
         value: value,
       ),

--- a/lib/src/stream/supabase_stream_limit_builder.dart
+++ b/lib/src/stream/supabase_stream_limit_builder.dart
@@ -8,8 +8,8 @@ class SupabaseLimitBuilder extends SupabaseStreamBuilder {
     required String schema,
     required String table,
     required List<String> primaryKey,
-    required StreamFilter? filter,
-    required StreamOrder? order,
+    required _StreamFilter? filter,
+    required _StreamOrder? order,
   }) : super(
           queryBuilder: queryBuilder,
           realtimeTopic: realtimeTopic,

--- a/lib/src/stream/supabase_stream_limit_builder.dart
+++ b/lib/src/stream/supabase_stream_limit_builder.dart
@@ -1,0 +1,43 @@
+part of 'supabase_stream_builder.dart';
+
+class SupabaseLimitBuilder extends SupabaseStreamBuilder {
+  SupabaseLimitBuilder({
+    required PostgrestQueryBuilder queryBuilder,
+    required String realtimeTopic,
+    required RealtimeClient realtimeClient,
+    required String schema,
+    required String table,
+    required List<String> primaryKey,
+    required StreamFilter? filter,
+    required StreamOrder? order,
+  }) : super(
+          queryBuilder: queryBuilder,
+          realtimeTopic: realtimeTopic,
+          realtimeClient: realtimeClient,
+          schema: schema,
+          table: table,
+          primaryKey: primaryKey,
+          filter: filter,
+          order: order,
+          limit: null,
+        );
+
+  /// Limits the result with the specified `count`.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).limit(10);
+  /// ```
+  SupabaseStreamBuilder limit(int count) {
+    return SupabaseStreamBuilder(
+      queryBuilder: _queryBuilder,
+      realtimeTopic: _realtimeTopic,
+      realtimeClient: _realtimeClient,
+      schema: _schema,
+      table: _table,
+      primaryKey: _uniqueColumns,
+      filter: _filter,
+      order: _order,
+      limit: count,
+    );
+  }
+}

--- a/lib/src/stream/supabase_stream_order_builder.dart
+++ b/lib/src/stream/supabase_stream_order_builder.dart
@@ -1,0 +1,45 @@
+part of 'supabase_stream_builder.dart';
+
+class SupabaseStreamOrderBuilder extends SupabaseLimitBuilder {
+  SupabaseStreamOrderBuilder({
+    required PostgrestQueryBuilder queryBuilder,
+    required String realtimeTopic,
+    required RealtimeClient realtimeClient,
+    required String schema,
+    required String table,
+    required List<String> primaryKey,
+    required StreamFilter? filter,
+  }) : super(
+          queryBuilder: queryBuilder,
+          realtimeTopic: realtimeTopic,
+          realtimeClient: realtimeClient,
+          schema: schema,
+          table: table,
+          primaryKey: primaryKey,
+          filter: filter,
+          order: null,
+        );
+
+  /// Orders the result with the specified [column].
+  ///
+  /// When `ascending` value is true, the result will be in ascending order.
+  ///
+  /// ```dart
+  /// supabase.from('users').stream(primaryKey: ['id']).order('username', ascending: false);
+  /// ```
+  SupabaseLimitBuilder order(String column, {bool ascending = false}) {
+    return SupabaseLimitBuilder(
+      queryBuilder: _queryBuilder,
+      realtimeTopic: _realtimeTopic,
+      realtimeClient: _realtimeClient,
+      schema: _schema,
+      table: _table,
+      primaryKey: _uniqueColumns,
+      filter: _filter,
+      order: StreamOrder(
+        column: column,
+        ascending: ascending,
+      ),
+    );
+  }
+}

--- a/lib/src/stream/supabase_stream_order_builder.dart
+++ b/lib/src/stream/supabase_stream_order_builder.dart
@@ -8,7 +8,7 @@ class SupabaseStreamOrderBuilder extends SupabaseLimitBuilder {
     required String schema,
     required String table,
     required List<String> primaryKey,
-    required StreamFilter? filter,
+    required _StreamFilter? filter,
   }) : super(
           queryBuilder: queryBuilder,
           realtimeTopic: realtimeTopic,
@@ -36,7 +36,7 @@ class SupabaseStreamOrderBuilder extends SupabaseLimitBuilder {
       table: _table,
       primaryKey: _uniqueColumns,
       filter: _filter,
-      order: StreamOrder(
+      order: _StreamOrder(
         column: column,
         ascending: ascending,
       ),

--- a/lib/src/supabase_query_builder.dart
+++ b/lib/src/supabase_query_builder.dart
@@ -1,5 +1,5 @@
 import 'package:http/http.dart';
-import 'package:supabase/src/supabase_stream_builder.dart';
+import 'package:supabase/src/stream/supabase_stream_builder.dart';
 import 'package:supabase/supabase.dart';
 import 'package:yet_another_json_isolate/yet_another_json_isolate.dart';
 
@@ -43,9 +43,9 @@ class SupabaseQueryBuilder extends PostgrestQueryBuilder {
   /// ```dart
   /// supabase.from('chats').stream(primaryKey: ['my_primary_key']).eq('room_id','123').order('created_at').limit(20).listen(_onChatsReceived);
   /// ```
-  SupabaseStreamBuilder stream({required List<String> primaryKey}) {
+  SupabaseStreamFilterBuilder stream({required List<String> primaryKey}) {
     assert(primaryKey.isNotEmpty, 'Please specify primary key column(s).');
-    return SupabaseStreamBuilder(
+    return SupabaseStreamFilterBuilder(
       queryBuilder: this,
       realtimeClient: _realtime,
       realtimeTopic: '$_schema:$_table:$_incrementId',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improves developer experience around filtering `.stream()`

## What is the current behavior?

Users could chain multiple filters on `.stream()` and it would not throw static error. Users could only find out that it's invalid after running the code.
```dart
supabase.from('table')
  .stream([])
  .eq('column', 'val')
  .neq('another_column', 'val')
  .lt('third_column', 'val')
  .listen((_) {});
```

## What is the new behavior?

Chaining multiple filters like this will be a static error.
```dart
supabase.from('table')
  .stream([])
  .eq('column', 'val')
  .neq('another_column', 'val')
  .lt('third_column', 'val')
  .listen((_) {});
```

