### PR TITLE
doc: fix status on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,7 @@ A Dart client for [Supabase](https://supabase.io/).
 
 ## Status
 
-- [x] Alpha: Under heavy development
-- [x] Public Alpha: Ready for testing. But go easy on us, there will be bugs and missing functionality.
-- [x] Public Beta: Stable. No breaking changes expected in this version but possible bugs.
-- [ ] Public: Production-ready
+Public Beta: Stable. No breaking changes expected in this version but possible bugs.
 
 ## Docs
 


### PR DESCRIPTION
The checkboxes don't get displayed on [pub.dev](https://pub.dev/packages/supabase#status), which result in a weird list. I've changed it now, that only the current status is shown. I'm open to other ways. We could remove it entirely as well, since it's not in the supabase_flutter readme.