### PR TITLE
test: allow web_socket_channel 2.3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,4 +20,4 @@ dependencies:
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.9
-  web_socket_channel: 2.2.0
+  web_socket_channel: ^2.2.0

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -165,7 +165,7 @@ void main() {
           webSocket!.add(replyString);
 
           // Send an insert event
-          await Future.delayed(Duration(milliseconds: 300));
+          await Future.delayed(Duration(milliseconds: 10));
           final insertString = jsonEncode({
             'topic': topic,
             'event': 'postgres_changes',
@@ -354,14 +354,21 @@ void main() {
 
   tearDown(() async {
     listeners.clear();
-    await listener?.cancel();
 
     await client.dispose();
+    await customHeadersClient.dispose();
+
+    //Manually disconnect the socket channel to avoid automatic retrying to reconnect. This caused failing in later executed tests.
+    client.realtime.disconnect();
+    customHeadersClient.realtime.disconnect();
 
     // Wait for the realtime updates to come through
     await Future.delayed(Duration(milliseconds: 100));
 
     await webSocket?.close();
+
+    await listener?.cancel();
+
     await mockServer.close();
   });
 

--- a/test/realtime_test.dart
+++ b/test/realtime_test.dart
@@ -35,6 +35,9 @@ void main() {
       await client.dispose();
       await client.removeAllChannels();
       await subscription.cancel();
+
+      await Future.delayed(Duration(milliseconds: 100));
+
       await mockServer.close(force: true);
     });
 


### PR DESCRIPTION
In order to be compatible with https://github.com/supabase/realtime-dart/pull/62, I had to fix the issue of depending on outdated version 2.2.0.
Adding another delay fixed [the issue](https://github.com/supabase/supabase-dart/pull/169#issuecomment-1381252913).