### PR TITLE
fix: keep one storage and functions instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.6.1]
+- fix: update storage to v1.2.3
+  - add `setAuth()` function
+- fix: keep one storage and functions instance to persist auth [#182](https://github.com/supabase/supabase-dart/pull/182)
+
 ## [1.6.0]
 - feat: update gotrue to v1.5.1
   - add support for `signInWithIdToken`

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -225,8 +225,8 @@ class SupabaseClient {
         event == AuthChangeEvent.signedIn && _changedAccessToken != token) {
       // Token has changed
       _changedAccessToken = token;
-      storage.setAuth(token);
-      functions.setAuth(token!);
+      storage.setAuth(token!);
+      functions.setAuth(token);
       realtime.setAuth(token);
     } else if (event == AuthChangeEvent.signedOut ||
         event == AuthChangeEvent.userDeleted) {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.6.0';
+const version = '1.6.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   http: ^0.13.4
   postgrest: ^1.2.2
   realtime_client: ^1.0.2
-  storage_client: ^1.2.2
+  storage_client: ^1.2.3
   rxdart: ^0.27.5
   yet_another_json_isolate: ^1.0.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 1.6.0
+version: 1.6.1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Everytime calling `supabse.storage` you get a new `SupabaseStorageClient` instance, resulting in outdated auth headers after auth state change in `supabase.auth`.

## What is the new behavior?

Keeps one storage and functions client and update their authorization header.

## Additional context

close https://github.com/supabase/supabase-flutter/issues/376
