### PR TITLE
make the headers property editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.8.0]
+- feat: make the headers property editable [#185](https://github.com/supabase/supabase-dart/pull/185)
+  ```dart
+  // Add custom headers using the `headers` setter
+  supabase.headers = {'my-headers': 'my-value'};
+  ```
+
 ## [1.7.0]
 - feat: add async storage as parameter to support pkce flow [#190](https://github.com/supabase/supabase-dart/pull/190)
 - fix: use onAuthStateChangeSync to set auth headers [#193](https://github.com/supabase/supabase-dart/pull/193)

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -42,6 +42,21 @@ class SupabaseClient {
   /// Number of retries storage client should do on file failed file uploads.
   final int _storageRetryAttempts;
 
+  /// Getter for the HTTP headers
+  Map<String, String> get headers {
+    return _headers;
+  }
+
+  /// Setter for the HTTP headers
+  set headers(Map<String, String> value) {
+    final keysToRemove =
+        _headers.keys.toSet().where((key) => !value.containsKey(key));
+
+    _headers
+      ..addAll(value)
+      ..removeWhere((key, _) => keysToRemove.contains(key));
+  }
+
   /// Creates a Supabase client to interact with your Supabase instance.
   ///
   /// [supabaseUrl] and [supabaseKey] can be found on your Supabase dashboard.

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -69,6 +69,30 @@ class SupabaseClient {
     return _headers;
   }
 
+  set headers(Map<String, String> headers) {
+    _headers.clear();
+    _headers.addAll({
+      ...Constants.defaultHeaders,
+      ..._getAuthHeaders(),
+      ...headers,
+    });
+
+    rest.headers.clear();
+    rest.headers.addAll(_headers);
+
+    realtime.headers.clear();
+    realtime.headers.addAll(_headers);
+
+    functions.headers.clear();
+    functions.headers.addAll(_headers);
+
+    storage.headers.clear();
+    storage.headers.addAll(_headers);
+
+    auth.headers.clear();
+    auth.headers.addAll(_headers);
+  }
+
   /// Creates a Supabase client to interact with your Supabase instance.
   ///
   /// [supabaseUrl] and [supabaseKey] can be found on your Supabase dashboard.

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -77,20 +77,17 @@ class SupabaseClient {
       ...headers,
     });
 
-    rest.headers.clear();
-    rest.headers.addAll(_headers);
+    rest.headers..clear()..addAll(_headers);
 
-    realtime.headers.clear();
-    realtime.headers.addAll(_headers);
+    functions.headers..clear()..addAll(_headers);
 
-    functions.headers.clear();
-    functions.headers.addAll(_headers);
+    storage.headers..clear()..addAll(_headers);
 
-    storage.headers.clear();
-    storage.headers.addAll(_headers);
-
-    auth.headers.clear();
-    auth.headers.addAll(_headers);
+    auth.headers..clear()..addAll(_headers);
+    
+    // To apply the new headers in the realtime client,
+    // manually unsubscribe and resubscribe to all channels.
+    realtime.headers..clear()..addAll(_headers);
   }
 
   /// Creates a Supabase client to interact with your Supabase instance.

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -69,6 +69,7 @@ class SupabaseClient {
     return _headers;
   }
 
+  /// To apply the new headers in existing realtime channels, manually unsubscribe and resubscribe these channels.
   set headers(Map<String, String> headers) {
     _headers.clear();
     _headers.addAll({
@@ -77,17 +78,27 @@ class SupabaseClient {
       ...headers,
     });
 
-    rest.headers..clear()..addAll(_headers);
+    rest.headers
+      ..clear()
+      ..addAll(_headers);
 
-    functions.headers..clear()..addAll(_headers);
+    functions.headers
+      ..clear()
+      ..addAll(_headers);
 
-    storage.headers..clear()..addAll(_headers);
+    storage.headers
+      ..clear()
+      ..addAll(_headers);
 
-    auth.headers..clear()..addAll(_headers);
-    
+    auth.headers
+      ..clear()
+      ..addAll(_headers);
+
     // To apply the new headers in the realtime client,
     // manually unsubscribe and resubscribe to all channels.
-    realtime.headers..clear()..addAll(_headers);
+    realtime.headers
+      ..clear()
+      ..addAll(_headers);
   }
 
   /// Creates a Supabase client to interact with your Supabase instance.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.7.0';
+const version = '1.8.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
-  functions_client: ^1.1.0
+  functions_client: ^1.2.0
   gotrue: ^1.7.0
   http: ^0.13.4
   postgrest: ^1.2.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 1.7.0
+version: 1.8.0
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces a feature that allows for greater customization of HTTP headers in the Supabase Dart library.

## What is the current behavior?

Currently, the library uses a private _headers field to store HTTP headers for every request. Users can't modify these headers outside of the library code.

## What is the new behavior?

This PR adds a getter and setter for the _headers field, allowing users to customize headers for specific requests, such as adding or removing headers as needed.

## Additional context

This change will give users more control over the headers used in their requests, making the Supabase Dart library more flexible and adaptable to their needs. No relevant issues were identified. No screenshots are necessary as this is a code change.

Here's an example of how the new feature can be used in the RLS with the device_uid() function:

Suppose you have a users table and want to allow read access to unauthenticated users only if they provide a valid x-device-uuid header. You can create a policy like this:

```sql
CREATE POLICY allow_read_unauthenticated ON users
  FOR SELECT
  USING (
    (auth.role() = 'anonymous' AND device_uid() IS NOT NULL) OR
    auth.uid() = id
  );
```

This policy allows unauthenticated users to read a row only if they provide a valid x-device-uuid header, or if the row belongs to them (identified by their uid).

this is the definition of device_uid() if someone need it 🙂 ✨
```sql
CREATE OR REPLACE FUNCTION device_uid() RETURNS uuid LANGUAGE sql STABLE AS $function$
SELECT NULLIF(
    current_setting('request.headers', true)::json->>'x-device-uuid',
    ''
  )::uuid;
$function$;
```