### PR TITLE
fix: keep one postgrest client

### DIFF
--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -230,14 +230,14 @@ class SupabaseClient {
         event == AuthChangeEvent.signedIn && _changedAccessToken != token) {
       // Token has changed
       _changedAccessToken = token;
-      rest.setAuth(token);
-      storage.setAuth(token!);
+      rest.auth(token!);
+      storage.setAuth(token);
       functions.setAuth(token);
       realtime.setAuth(token);
     } else if (event == AuthChangeEvent.signedOut ||
         event == AuthChangeEvent.userDeleted) {
       // Token is removed
-      rest.setAuth(supabaseKey);
+      rest.auth(supabaseKey);
       storage.setAuth(supabaseKey);
       functions.setAuth(supabaseKey);
       realtime.setAuth(supabaseKey);

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -231,7 +231,7 @@ class SupabaseClient {
       // Token has changed
       _changedAccessToken = token;
       rest.setAuth(token);
-      storage.setsetAuth(token!);
+      storage.setAuth(token!);
       functions.setAuth(token);
       realtime.setAuth(token);
     } else if (event == AuthChangeEvent.signedOut ||

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -237,7 +237,7 @@ class SupabaseClient {
     } else if (event == AuthChangeEvent.signedOut ||
         event == AuthChangeEvent.userDeleted) {
       // Token is removed
-      rest.auth(supabaseKey);
+      rest.setAuth(supabaseKey);
       storage.setAuth(supabaseKey);
       functions.setAuth(supabaseKey);
       realtime.setAuth(supabaseKey);

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -230,8 +230,8 @@ class SupabaseClient {
         event == AuthChangeEvent.signedIn && _changedAccessToken != token) {
       // Token has changed
       _changedAccessToken = token;
-      rest.auth(token!);
-      storage.setAuth(token);
+      rest.setAuth(token);
+      storage.setsetAuth(token!);
       functions.setAuth(token);
       realtime.setAuth(token);
     } else if (event == AuthChangeEvent.signedOut ||

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   functions_client: ^1.1.0
   gotrue: ^1.5.1
   http: ^0.13.4
-  postgrest: ^1.2.2
+  postgrest: ^1.2.3
   realtime_client: ^1.0.2
   storage_client: ^1.2.3
   rxdart: ^0.27.5


### PR DESCRIPTION
I noticed the `rest` variable is neither used nor set. I'm now using it to be able to set the headers correctly.