### PR TITLE
fix: copy headers value on from() call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.6.3]
+- fix: copy headers value on from() call [#189](https://github.com/supabase/supabase-dart/pull/189)
+
 ## [1.6.2]
 - fix: handle onAuthStateChange errors silently [#187](https://github.com/supabase/supabase-dart/pull/187)
 - fix: persist a single postgrest client [#186](https://github.com/supabase/supabase-dart/pull/186)

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -104,7 +104,7 @@ class SupabaseClient {
     return SupabaseQueryBuilder(
       url,
       realtime,
-      headers: rest.headers,
+      headers: {...rest.headers},
       schema: schema,
       table: table,
       httpClient: _httpClient,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.6.2';
+const version = '1.6.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 1.6.2
+version: 1.6.3
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Makes sure the headers is copied over in `from()` call.

Currently, if a user performs the following query, the second query fails, because the headers for the `single()` query remains. 

```dart
final singleRow = await supabase.from('random').select().limit(1).single();
final multipleRows = await supabase.from('random').select();
```

This PR fixes it by copying over the `rest.headers` on the `from()` call.

fixes https://github.com/supabase/supabase-flutter/issues/430