### PR TITLE
fix: going back to using auth headers for SupabaseQueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.6.4]
+- fix: race condition for passing auth headers for rest client [#192](https://github.com/supabase/supabase-dart/pull/192)
+
+
 ## [1.6.3]
 - fix: copy headers value on from() call [#189](https://github.com/supabase/supabase-dart/pull/189)
 

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -104,7 +104,10 @@ class SupabaseClient {
     return SupabaseQueryBuilder(
       url,
       realtime,
-      headers: _getAuthHeaders(),
+      headers: {
+        ...rest.headers,
+        ..._getAuthHeaders(),
+      },
       schema: schema,
       table: table,
       httpClient: _httpClient,
@@ -121,7 +124,10 @@ class SupabaseClient {
   }) {
     return PostgrestClient(
       '$supabaseUrl/rest/v1',
-      headers: _getAuthHeaders(),
+      headers: {
+        ...rest.headers,
+        ..._getAuthHeaders(),
+      },
       schema: schema,
       httpClient: _httpClient,
     ).rpc(fn, params: params);

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -119,7 +119,12 @@ class SupabaseClient {
     Map<String, dynamic>? params,
     FetchOptions options = const FetchOptions(),
   }) {
-    return rest.rpc(fn, params: params, options: options);
+    return PostgrestClient(
+      '$supabaseUrl/rest/v1',
+      headers: _getAuthHeaders(),
+      schema: schema,
+      httpClient: _httpClient,
+    ).rpc(fn, params: params);
   }
 
   /// Creates a Realtime channel with Broadcast, Presence, and Postgres Changes.

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -122,15 +122,8 @@ class SupabaseClient {
     Map<String, dynamic>? params,
     FetchOptions options = const FetchOptions(),
   }) {
-    return PostgrestClient(
-      '$supabaseUrl/rest/v1',
-      headers: {
-        ...rest.headers,
-        ..._getAuthHeaders(),
-      },
-      schema: schema,
-      httpClient: _httpClient,
-    ).rpc(fn, params: params);
+    rest.headers.addAll({...rest.headers, ..._getAuthHeaders()});
+    return rest.rpc(fn, params: params, options: options);
   }
 
   /// Creates a Realtime channel with Broadcast, Presence, and Postgres Changes.

--- a/lib/src/supabase_client.dart
+++ b/lib/src/supabase_client.dart
@@ -104,7 +104,7 @@ class SupabaseClient {
     return SupabaseQueryBuilder(
       url,
       realtime,
-      headers: {...rest.headers},
+      headers: _getAuthHeaders(),
       schema: schema,
       table: table,
       httpClient: _httpClient,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.6.3';
+const version = '1.6.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase
 description: A dart client for Supabase. This client makes it simple for developers to build secure and scalable products.
-version: 1.6.3
+version: 1.6.4
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/supabase-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, when user performs an query right after signing in, the query is performed with the session prior to signing in, resulting in empty query result. This PR fixes that.

```dart
await client.auth.signInWithPassword(email: email, password: password);

/// Unable to retrieve data if the data is protected with RLS
final data = await client
    .from('profiles')
    .select()
    .eq('user_id', response.user?.id);
```

Fixes https://github.com/supabase/supabase-flutter/issues/456